### PR TITLE
fix issue when merging config

### DIFF
--- a/src/Providers/SendStackServiceProvider.php
+++ b/src/Providers/SendStackServiceProvider.php
@@ -14,9 +14,7 @@ class SendStackServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(
             path: __DIR__.'/../../config/services.php',
-            key: config_path(
-                path: 'services',
-            )
+            key: 'services',
         );
     }
 

--- a/tests/Feature/ConfigTest.php
+++ b/tests/Feature/ConfigTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+it('url is not null', function () {
+    $url = config()->get('services.sendstack.url');
+
+    expect($url)->not()->toBeEmpty();
+});


### PR DESCRIPTION
This PR fixes wrong merging of configuration files which causes `$url` to be `null`.

This PR closes https://github.com/getsendstack/laravel-sendstack/issues/4.